### PR TITLE
feat: add onOperationComplete & onOperationError callbacks

### DIFF
--- a/Sources/GraphQLWS/Server.swift
+++ b/Sources/GraphQLWS/Server.swift
@@ -19,8 +19,8 @@ public class Server<InitPayload: Equatable & Codable> {
     var auth: (InitPayload) throws -> Void = { _ in }
     var onExit: () -> Void = { }
     var onMessage: (String) -> Void = { _ in }
-    var onOperationComplete: () -> Void = {}
-    var onOperationError: () -> Void = {}
+    var onOperationComplete: (String) -> Void = { _ in }
+    var onOperationError: (String) -> Void = { _ in }
     
     var initialized = false
     
@@ -87,7 +87,7 @@ public class Server<InitPayload: Equatable & Codable> {
                         self.error(.invalidRequestFormat(messageType: .GQL_STOP))
                         return
                     }
-                    self.onStop(stopRequest, messenger)
+                    self.onOperationComplete(stopRequest.id)
                 case .GQL_CONNECTION_TERMINATE:
                     guard let connectionTerminateRequest = try? self.decoder.decode(ConnectionTerminateRequest.self, from: json) else {
                         self.error(.invalidRequestFormat(messageType: .GQL_CONNECTION_TERMINATE))
@@ -121,13 +121,13 @@ public class Server<InitPayload: Equatable & Codable> {
     
     /// Define the callback run on the completion a full operation (query/mutation, end of subscription)
     /// - Parameter callback: The callback to assign
-    public func onOperationComplete(_ callback: @escaping () -> Void) {
+    public func onOperationComplete(_ callback: @escaping (String) -> Void) {
         self.onOperationComplete = callback
     }
     
     /// Define the callback to run on error of any full operation (failed query, interrupted subscription)
     /// - Parameter callback: The callback to assign
-    public func onOperationError(_ callback: @escaping () -> Void) {
+    public func onOperationError(_ callback: @escaping (String) -> Void) {
         self.onOperationError = callback
     }
     
@@ -216,14 +216,6 @@ public class Server<InitPayload: Equatable & Codable> {
         }
     }
     
-    private func onStop(_: StopRequest, _ messenger: Messenger) {
-        guard initialized else {
-            self.error(.notInitialized())
-            return
-        }
-        onOperationComplete()
-    }
-    
     private func onConnectionTerminate(_: ConnectionTerminateRequest, _ messenger: Messenger) {
         onExit()
         _ = messenger.close()
@@ -272,7 +264,7 @@ public class Server<InitPayload: Equatable & Codable> {
                 id: id
             ).toJSON(encoder)
         )
-        onOperationComplete()
+        onOperationComplete(id)
     }
     
     /// Send an `error` response through the messenger
@@ -284,7 +276,7 @@ public class Server<InitPayload: Equatable & Codable> {
                 id: id
             ).toJSON(encoder)
         )
-        onOperationError()
+        onOperationError(id)
     }
     
     /// Send an `error` response through the messenger

--- a/Sources/GraphQLWS/Server.swift
+++ b/Sources/GraphQLWS/Server.swift
@@ -19,6 +19,7 @@ public class Server<InitPayload: Equatable & Codable> {
     var auth: (InitPayload) throws -> Void = { _ in }
     var onExit: () -> Void = { }
     var onMessage: (String) -> Void = { _ in }
+    var onStop: () -> Void = { }
     
     var initialized = false
     
@@ -66,6 +67,7 @@ public class Server<InitPayload: Equatable & Codable> {
                 return
             }
             
+            // handle incoming message
             switch request.type {
                 case .GQL_CONNECTION_INIT:
                     guard let connectionInitRequest = try? self.decoder.decode(ConnectionInitRequest<InitPayload>.self, from: json) else {
@@ -114,6 +116,12 @@ public class Server<InitPayload: Equatable & Codable> {
     /// - Parameter callback: The callback to assign
     public func onMessage(_ callback: @escaping (String) -> Void) {
         self.onMessage = callback
+    }
+    
+    /// Define the callback run on receipt of a`GQL_STOP` message
+    /// - Parameter callback: The callback to assign
+    public func onStop(_ callback: @escaping () -> Void) {
+        self.onStop = callback
     }
     
     private func onConnectionInit(_ connectionInitRequest: ConnectionInitRequest<InitPayload>, _ messenger: Messenger) {
@@ -206,6 +214,7 @@ public class Server<InitPayload: Equatable & Codable> {
             self.error(.notInitialized())
             return
         }
+        onStop()
     }
     
     private func onConnectionTerminate(_: ConnectionTerminateRequest, _ messenger: Messenger) {


### PR DESCRIPTION
Adds an onStop callback & registration function for configuring behavior when the server receives a [GQL_STOP](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_stop) message