### PR TITLE
Server error exposure

### DIFF
--- a/Sources/GraphQLWS/Server.swift
+++ b/Sources/GraphQLWS/Server.swift
@@ -18,7 +18,7 @@ public class Server<InitPayload: Equatable & Codable> {
     var onExit: () -> Void = { }
     var onMessage: (String) -> Void = { _ in }
     var onOperationComplete: (String) -> Void = { _ in }
-    var onOperationError: (String) -> Void = { _ in }
+    var onOperationError: (String, [Error]) -> Void = { _, _ in }
     
     var initialized = false
     
@@ -128,7 +128,7 @@ public class Server<InitPayload: Equatable & Codable> {
     
     /// Define the callback to run on error of any full operation (failed query, interrupted subscription)
     /// - Parameter callback: The callback to assign
-    public func onOperationError(_ callback: @escaping (String) -> Void) {
+    public func onOperationError(_ callback: @escaping (String, [Error]) -> Void) {
         self.onOperationError = callback
     }
     
@@ -283,7 +283,7 @@ public class Server<InitPayload: Equatable & Codable> {
                 id: id
             ).toJSON(encoder)
         )
-        onOperationError(id)
+        onOperationError(id, errors)
     }
     
     /// Send an `error` response through the messenger


### PR DESCRIPTION
Adds errors to `Server.onOperationError` callback to allow for users to log, etc.